### PR TITLE
Document package APIs and add missing __init__ modules

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -6,4 +6,13 @@ Core source code for the Dream.OS Cell Phone system.
 
 __version__ = "1.0.0"
 __author__ = "Dream.OS Team"
-__description__ = "Autonomous agent communication system" 
+__description__ = "Autonomous agent communication system"
+
+__all__ = [
+    "agent_cell_phone",
+    "framework",
+    "gui",
+    "inter_agent_framework",
+    "runtime",
+    "utils",
+]

--- a/src/framework/__init__.py
+++ b/src/framework/__init__.py
@@ -2,4 +2,9 @@
 Dream.OS Cell Phone - Framework Package
 =======================================
 Core framework components for the Dream.OS Cell Phone system.
-""" 
+
+Public API:
+- agent_autonomy_framework
+"""
+
+__all__ = ["agent_autonomy_framework"]

--- a/src/gui/__init__.py
+++ b/src/gui/__init__.py
@@ -1,1 +1,13 @@
-# Dream.OS GUI Package 
+"""
+Dream.OS GUI package.
+
+Collects all graphical user interface components, including reusable widgets,
+tabs, and utility helpers.
+
+Public API:
+- components: reusable widgets package
+- tabs: tab implementations
+- utils: GUI helper utilities
+"""
+
+__all__ = ["components", "tabs", "utils"]

--- a/src/gui/components/__init__.py
+++ b/src/gui/components/__init__.py
@@ -1,0 +1,67 @@
+"""
+Reusable GUI components for Dream.OS Cell Phone.
+
+This package exposes reusable widgets used throughout the GUI.
+
+Public API:
+- TkCustomMessageWidget
+- QtCustomMessageWidget
+- OnboardingProgressWidget
+- OnboardingStatusWidget
+- OnboardingLogWidget
+- OnboardingControlsWidget
+- OnboardingChecklistWidget
+- OnboardingManager
+- QtOnboardingProgressWidget
+- QtOnboardingStatusWidget
+- QtOnboardingLogWidget
+- QtOnboardingControlsWidget
+- QtOnboardingChecklistWidget
+- OnboardingDashboardWidget
+"""
+
+from .custom_message_widget import CustomMessageWidget as TkCustomMessageWidget
+from .onboarding_components import (
+    OnboardingProgressWidget,
+    OnboardingStatusWidget,
+    OnboardingLogWidget,
+    OnboardingControlsWidget,
+    OnboardingChecklistWidget,
+    OnboardingManager,
+)
+from .onboarding_dashboard import OnboardingDashboardWidget
+
+# Optional PyQt5 components
+try:  # pragma: no cover - optional dependency
+    from .custom_message_widget_qt import CustomMessageWidget as QtCustomMessageWidget
+    from .onboarding_components_qt import (
+        OnboardingProgressWidget as QtOnboardingProgressWidget,
+        OnboardingStatusWidget as QtOnboardingStatusWidget,
+        OnboardingLogWidget as QtOnboardingLogWidget,
+        OnboardingControlsWidget as QtOnboardingControlsWidget,
+        OnboardingChecklistWidget as QtOnboardingChecklistWidget,
+    )
+except Exception:  # ImportError, RuntimeError, etc.
+    QtCustomMessageWidget = None
+    QtOnboardingProgressWidget = None
+    QtOnboardingStatusWidget = None
+    QtOnboardingLogWidget = None
+    QtOnboardingControlsWidget = None
+    QtOnboardingChecklistWidget = None
+
+__all__ = [
+    "TkCustomMessageWidget",
+    "QtCustomMessageWidget",
+    "OnboardingProgressWidget",
+    "OnboardingStatusWidget",
+    "OnboardingLogWidget",
+    "OnboardingControlsWidget",
+    "OnboardingChecklistWidget",
+    "OnboardingManager",
+    "QtOnboardingProgressWidget",
+    "QtOnboardingStatusWidget",
+    "QtOnboardingLogWidget",
+    "QtOnboardingControlsWidget",
+    "QtOnboardingChecklistWidget",
+    "OnboardingDashboardWidget",
+]

--- a/src/gui/tabs/__init__.py
+++ b/src/gui/tabs/__init__.py
@@ -1,1 +1,16 @@
-# Dream.OS GUI Tabs Package 
+"""
+GUI tab implementations for Dream.OS.
+
+Provides ready-to-use tabs for various system functions.
+
+Public API:
+- AgentMessengerTab
+- CoordinatorTab
+- OnboardingTab
+"""
+
+from .agent_messenger_tab import AgentMessengerTab
+from .coordinator_tab import CoordinatorTab
+from .onboarding_tab import OnboardingTab
+
+__all__ = ["AgentMessengerTab", "CoordinatorTab", "OnboardingTab"]

--- a/src/runtime/__init__.py
+++ b/src/runtime/__init__.py
@@ -1,0 +1,10 @@
+"""
+Runtime utilities for Dream.OS Cell Phone.
+
+This package contains runtime resources such as configuration files.
+
+Public API:
+- config: access to runtime configuration data
+"""
+
+__all__ = ["config"]

--- a/src/runtime/config/__init__.py
+++ b/src/runtime/config/__init__.py
@@ -1,0 +1,25 @@
+"""
+Runtime configuration resources.
+
+Provides helper functions to load configuration files shipped with the
+package.
+
+Public API:
+- get_cursor_agent_coords: load default cursor agent coordinate mapping.
+"""
+
+from importlib.resources import files
+
+
+def get_cursor_agent_coords() -> bytes:
+    """Return the raw contents of ``cursor_agent_coords.json``.
+
+    Returns
+    -------
+    bytes
+        Raw bytes of the JSON configuration file.
+    """
+    return files(__package__).joinpath("cursor_agent_coords.json").read_bytes()
+
+
+__all__ = ["get_cursor_agent_coords"]

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -2,4 +2,23 @@
 Dream.OS Cell Phone - Utils Package
 ===================================
 Utility modules for the Dream.OS Cell Phone system.
-""" 
+
+Public API:
+- base_gui_controller
+- coordination_utils
+- messaging_utils
+- onboarding_utils
+- shared_classes
+- shared_operations
+- unified_broadcast_service
+"""
+
+__all__ = [
+    "base_gui_controller",
+    "coordination_utils",
+    "messaging_utils",
+    "onboarding_utils",
+    "shared_classes",
+    "shared_operations",
+    "unified_broadcast_service",
+]


### PR DESCRIPTION
## Summary
- Add package initializers for GUI components and runtime modules with documented public APIs
- Export key tab and utility interfaces through updated `__init__` modules
- Provide helper to load runtime cursor agent coordinates

## Testing
- `pytest` *(fails: KeyError: 'DISPLAY' and ModuleNotFoundError: No module named 'agent_cell_phone')*

------
https://chatgpt.com/codex/tasks/task_e_68985c0e3db48329b423cd2f36a8e7d8