### PR TITLE
Add smoke test suite and nightly CI workflow

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,0 +1,24 @@
+name: Smoke Tests
+
+on:
+  push:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run smoke tests
+        run: |
+          pytest tests/smoke/test_smoke.py -vv

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+import types
+
+import pytest
+
+# Add the src directory to the path so tests can import project modules
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+# Provide a stub for pyautogui to avoid display requirements during tests
+sys.modules.setdefault("pyautogui", types.ModuleType("pyautogui"))
+
+from agent_cell_phone import AgentCellPhone, AgentMessage, MsgTag
+
+
+def test_smoke_message_flow():
+    """Basic smoke test ensuring send/receive workflow works headlessly."""
+    agent1 = AgentCellPhone(agent_id="Agent-1", layout_mode="2-agent", test=True)
+    agent2 = AgentCellPhone(agent_id="Agent-2", layout_mode="2-agent", test=True)
+
+    agent1.start_listening()
+    agent2.start_listening()
+    try:
+        # Send message from Agent-1 to Agent-2
+        agent1.send("Agent-2", "Hello Agent-2!", MsgTag.NORMAL)
+
+        # Simulate Agent-2 receiving the message
+        incoming = AgentMessage("Agent-1", "Agent-2", "Hello Agent-2!", MsgTag.NORMAL)
+        agent2._handle_incoming_message(incoming)
+
+        # Agent-2 replies back
+        agent2.reply("Agent-1", "Hello Agent-1!", MsgTag.REPLY)
+
+        # Simulate Agent-1 receiving the reply
+        reply_msg = AgentMessage("Agent-2", "Agent-1", "Hello Agent-1!", MsgTag.REPLY)
+        agent1._handle_incoming_message(reply_msg)
+
+        history1 = agent1.get_conversation_history()
+        assert any(msg.from_agent == "Agent-1" and msg.to_agent == "Agent-2" for msg in history1)
+        assert any(msg.from_agent == "Agent-2" and msg.to_agent == "Agent-1" for msg in history1)
+    finally:
+        agent1.stop_listening()
+        agent2.stop_listening()


### PR DESCRIPTION
## Summary
- add headless smoke test covering minimal message send/receive
- schedule smoke tests in GitHub Actions on every push and nightly

## Testing
- `pytest tests/smoke/test_smoke.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68985ce5a598832992dd72612801d415