### PR TITLE
Introduce unified configuration loader

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -1,0 +1,15 @@
+{
+  "paths": {
+    "agent_workspaces": "agent_workspaces",
+    "gui_root": "gui",
+    "examples_root": "examples",
+    "runtime_config": "src/runtime/config"
+  },
+  "environment": {
+    "log_level": "INFO",
+    "default_agent_layout": "2-agent"
+  },
+  "services": {
+    "messenger_api": "https://api.example.com"
+  }
+}

--- a/config/settings.prod.json
+++ b/config/settings.prod.json
@@ -1,0 +1,8 @@
+{
+  "environment": {
+    "log_level": "WARNING"
+  },
+  "services": {
+    "messenger_api": "https://prod.example.com"
+  }
+}

--- a/main.py
+++ b/main.py
@@ -8,8 +8,10 @@ Central launcher for all components of the Agent Cell Phone system.
 import os
 import sys
 import subprocess
-import json
-from pathlib import Path
+
+from src.core.config_loader import load_config
+
+CONFIG = load_config()
 
 def print_banner():
     """Print the application banner."""
@@ -104,13 +106,14 @@ def show_project_status():
     print("-" * 40)
     
     # Check key directories and files
+    paths = CONFIG.get("paths", {})
     status_items = [
-        ("📁 Agent Workspaces", "agent_workspaces/"),
+        ("📁 Agent Workspaces", paths.get("agent_workspaces", "agent_workspaces/")),
         ("📁 Source Code", "src/"),
-        ("📁 GUI Components", "gui/"),
+        ("📁 GUI Components", paths.get("gui_root", "gui/")),
         ("📁 Configuration", "config/"),
         ("📁 Documentation", "docs/"),
-        ("📁 Examples", "examples/"),
+        ("📁 Examples", paths.get("examples_root", "examples/")),
         ("📁 Tests", "tests/"),
         ("📁 Scripts", "scripts/"),
         ("📁 PRDs", "project_repository/PRDs/"),

--- a/src/agent_cell_phone.py
+++ b/src/agent_cell_phone.py
@@ -18,18 +18,27 @@ import queue
 
 try:
     import pyautogui  # mechanical control
-except ImportError:
-    pyautogui = None                          # tolerates headless tests
+except Exception:
+    pyautogui = None  # tolerates headless tests and missing displays
+
+from core.config_loader import load_config
+
+_CONFIG = load_config()
+_PATHS = _CONFIG.get("paths", {})
+_ENV = _CONFIG.get("environment", {})
+
+_REPO_ROOT = Path(_PATHS.get("repo_root", Path(__file__).resolve().parent.parent))
 
 # ──────────────────────────── config paths
-REPO_ROOT   = Path(__file__).resolve().parent    # Current directory
-CONFIG_DIR  = REPO_ROOT / "runtime" / "config"
+CONFIG_DIR  = Path(_PATHS.get("runtime_config", "src/runtime/config"))
+if not CONFIG_DIR.is_absolute():
+    CONFIG_DIR = _REPO_ROOT / CONFIG_DIR
 COORD_FILE  = CONFIG_DIR / "cursor_agent_coords.json"
 MODE_FILE   = CONFIG_DIR / "templates" / "agent_modes.json"
 
 # ──────────────────────────── logging
 logging.basicConfig(
-    level=logging.INFO,
+    level=getattr(logging, _ENV.get("log_level", "INFO").upper(), logging.INFO),
     format="%(asctime)s | %(levelname)7s | %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
 )
@@ -66,11 +75,14 @@ class AgentMessage:
         return f"{self.from_agent} → {self.to_agent}: {self.tag.value} {self.content}"
 
 # ──────────────────────────── core class
+DEFAULT_LAYOUT = _ENV.get("default_agent_layout", "2-agent")
+
+
 class AgentCellPhone:
     """Deterministic messenger for Cursor agents with inter-agent communication."""
 
     # public API ─────────────────────────
-    def __init__(self, agent_id: str = "Agent-1", layout_mode: str = "2-agent", test: bool = False) -> None:
+    def __init__(self, agent_id: str = "Agent-1", layout_mode: str = DEFAULT_LAYOUT, test: bool = False) -> None:
         self._agent_id = self._fmt_id(agent_id)
         self._layout_mode = layout_mode
         self._all_coords = self._load_json(COORD_FILE, "coordinates")

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core utilities package."""

--- a/src/core/config_loader.py
+++ b/src/core/config_loader.py
@@ -1,0 +1,56 @@
+"""Configuration loading utilities."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+
+def _deep_update(base: Dict[str, Any], overrides: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursively update ``base`` dict with ``overrides`` dict."""
+    for key, value in overrides.items():
+        if (
+            key in base
+            and isinstance(base[key], dict)
+            and isinstance(value, dict)
+        ):
+            _deep_update(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+def load_config(env: str = "default") -> Dict[str, Any]:
+    """Load the project configuration.
+
+    Parameters
+    ----------
+    env:
+        Optional environment name. If provided and a file named
+        ``settings.<env>.json`` exists in the config directory, its values
+        will overlay the defaults.
+
+    Returns
+    -------
+    dict
+        Dictionary containing merged configuration values.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    config_dir = repo_root / "config"
+
+    base_file = config_dir / "settings.json"
+    with base_file.open("r", encoding="utf-8") as f:
+        config: Dict[str, Any] = json.load(f)
+
+    # Expose repository root for consumers needing absolute paths
+    config.setdefault("paths", {})["repo_root"] = str(repo_root)
+
+    if env and env != "default":
+        env_file = config_dir / f"settings.{env}.json"
+        if env_file.exists():
+            with env_file.open("r", encoding="utf-8") as f:
+                env_config = json.load(f)
+            _deep_update(config, env_config)
+
+    return config


### PR DESCRIPTION
## Summary
- Add central `config/settings.json` and production overlay
- Implement `core.config_loader.load_config` with environment overrides
- Use config loader in `main.py` and `agent_cell_phone.py` to replace hardcoded paths and defaults

## Testing
- `PYTHONPATH=src pytest tests/test_special_chars.py`
- `PYTHONPATH=src pytest tests/test_8_agent_coordinates.py`
- `PYTHONPATH=src pytest tests/diagnostic_test.py`
- `PYTHONPATH=src pytest tests/test_inter_agent_framework.py`
- `PYTHONPATH=src pytest tests/test_harness.py` *(fails: fixture 'agent_id' not found)*


------
https://chatgpt.com/codex/tasks/task_e_68985c4deb4c83298102daa7fd6e2397