### PR TITLE
chore: clean up unused imports and fix onboarding status

### DIFF
--- a/gui/components/agent_panel.py
+++ b/gui/components/agent_panel.py
@@ -1,7 +1,6 @@
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QFrame, QLabel, QPushButton, QGroupBox, QProgressBar
 from PyQt5.QtCore import Qt, QTimer
 import json
-import os
 from pathlib import Path
 
 # Import onboarding integration

--- a/gui/components/onboarding_integration.py
+++ b/gui/components/onboarding_integration.py
@@ -6,9 +6,8 @@ Provides onboarding status loading and management for GUI components.
 """
 
 import json
-import os
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict
 from datetime import datetime
 
 class OnboardingIntegration:
@@ -88,7 +87,7 @@ class OnboardingIntegration:
                     "completed_steps": [],
                     "current_step": None,
                     "start_date": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-                    "completion_date": null,
+                    "completion_date": None,
                     "verification_passed": False,
                     "checklist": {
                         "quick_start_completed": False,

--- a/src/framework/agent_autonomy_framework.py
+++ b/src/framework/agent_autonomy_framework.py
@@ -8,7 +8,6 @@ Core framework for autonomous agent development and coordination.
 import json
 import logging
 import os
-import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Any

--- a/src/inter_agent_framework.py
+++ b/src/inter_agent_framework.py
@@ -11,7 +11,6 @@ Advanced messaging system for coordinated agent operations
 
 import json
 import logging
-import time
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path

--- a/src/utils/coordinate_finder.py
+++ b/src/utils/coordinate_finder.py
@@ -8,7 +8,6 @@ Utility for finding and managing cursor coordinates for agent communication.
 import json
 import logging
 import os
-import sys
 from pathlib import Path
 from typing import Dict, List, Tuple, Optional
 


### PR DESCRIPTION
## Summary
- remove unused imports in framework, utils, and gui modules
- fix invalid `null` value in onboarding integration with Python's `None`
- note: `flake8` not available in environment (403 during installation)

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68985c9725a883299993ae206b30cd15