### PR TITLE
Add configuration validation, retries, and watchdog monitoring

### DIFF
--- a/src/config_validator.py
+++ b/src/config_validator.py
@@ -1,0 +1,60 @@
+"""Configuration validation utilities.
+
+This module provides a simple validator that ensures required
+configuration files exist and contain valid JSON. It is intended to
+run during startup before any other components are initialized.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Iterable
+
+# Paths to configuration files that must exist for the application to run.
+REQUIRED_FILES = [
+    "config/agents/agent_coordinates.json",
+    "config/agents/agent_roles.json",
+    "config/system/system_config.json",
+    "config/templates/agent_modes.json",
+    "config/templates/message_templates.json",
+]
+
+
+def validate_config(files: Iterable[str] | None = None) -> bool:
+    """Validate that required configuration files exist and are valid JSON.
+
+    Parameters
+    ----------
+    files:
+        Iterable of file paths to validate. If ``None``, ``REQUIRED_FILES``
+        is used.
+
+    Returns
+    -------
+    bool
+        ``True`` if all files exist and contain valid JSON.
+
+    Raises
+    ------
+    FileNotFoundError
+        If any required file is missing.
+    ValueError
+        If any file contains invalid JSON.
+    """
+
+    files = files or REQUIRED_FILES
+    for path in files:
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"Missing configuration file: {path}")
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                json.load(f)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON in {path}: {exc.msg}") from exc
+    return True
+
+
+if __name__ == "__main__":
+    validate_config()
+    print("Configuration validated successfully.")

--- a/src/core/utils/retry.py
+++ b/src/core/utils/retry.py
@@ -1,0 +1,48 @@
+"""Utility functions for retrying operations with timeouts."""
+
+from __future__ import annotations
+
+import time
+from functools import wraps
+from typing import Any, Callable, Iterable, Tuple, Type
+
+
+ExceptionTypes = Iterable[Type[BaseException]]
+
+
+def retry(
+    retries: int = 3,
+    delay: float = 0.5,
+    exceptions: ExceptionTypes = (Exception,),
+    timeout: float | None = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Retry a function upon failure with optional timeout.
+
+    Parameters
+    ----------
+    retries:
+        Number of retry attempts before giving up.
+    delay:
+        Delay in seconds between attempts.
+    exceptions:
+        Exceptions that trigger a retry.
+    timeout:
+        Maximum total time in seconds for all attempts. ``None`` means no timeout.
+    """
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            deadline = time.time() + timeout if timeout is not None else None
+            attempt = 0
+            while True:
+                try:
+                    return func(*args, **kwargs)
+                except exceptions:  # type: ignore[misc]
+                    attempt += 1
+                    if attempt > retries or (deadline and time.time() > deadline):
+                        raise
+                    time.sleep(delay)
+        return wrapper
+
+    return decorator

--- a/src/core/utils/watchdog.py
+++ b/src/core/utils/watchdog.py
@@ -1,0 +1,50 @@
+"""Simple watchdog monitoring utilities."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Callable
+
+
+class Watchdog:
+    """Periodically run a check function and report failures."""
+
+    def __init__(
+        self,
+        interval: float,
+        check_fn: Callable[[], None],
+        alert_fn: Callable[[BaseException], None] | None = None,
+    ) -> None:
+        self.interval = interval
+        self.check_fn = check_fn
+        self.alert_fn = alert_fn or self._default_alert
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    @staticmethod
+    def _default_alert(error: BaseException) -> None:  # pragma: no cover - logging
+        logging.error("Watchdog detected failure: %s", error)
+
+    def start(self) -> None:
+        """Start the watchdog in a background thread."""
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Stop the watchdog thread."""
+        self._stop_event.set()
+        if self._thread:
+            self._thread.join(timeout=self.interval * 2)
+
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                self.check_fn()
+            except Exception as exc:  # pragma: no cover - alert path
+                self.alert_fn(exc)
+            time.sleep(self.interval)

--- a/startup.py
+++ b/startup.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Unified startup script for the Agent Cell Phone project.
+
+The script performs basic configuration validation before handing off
+control to the main application logic. Additional initialization steps
+can be added here in the future to keep startup consistent across
+environments.
+"""
+
+from src.config_validator import validate_config
+from src.core.utils.retry import retry
+
+
+@retry(retries=3, delay=1.0, exceptions=(Exception,), timeout=5)
+def _validated_startup() -> None:
+    """Validate configuration with automatic retries."""
+    validate_config()
+
+
+def main() -> None:
+    """Run the startup sequence."""
+    try:
+        _validated_startup()
+        print("Startup sequence completed. Configuration is valid.")
+    except Exception as exc:  # pragma: no cover - startup diagnostics
+        print(f"Startup failed: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_config_validator.py
+++ b/tests/test_config_validator.py
@@ -1,0 +1,24 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from src.config_validator import validate_config
+
+
+def test_validate_config_success():
+    assert validate_config()
+
+
+def test_validate_config_missing_file(tmp_path, monkeypatch):
+    missing_file = tmp_path / "missing.json"
+    with pytest.raises(FileNotFoundError):
+        validate_config([str(missing_file)])
+
+
+def test_validate_config_invalid_json(tmp_path):
+    invalid_file = tmp_path / "bad.json"
+    invalid_file.write_text("{invalid}")
+    with pytest.raises(ValueError):
+        validate_config([str(invalid_file)])

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,28 @@
+from src.core.utils.retry import retry
+
+
+def test_retry_succeeds_after_failures():
+    calls = {"count": 0}
+
+    @retry(retries=2, delay=0)
+    def flaky():
+        calls["count"] += 1
+        if calls["count"] < 2:
+            raise ValueError("fail")
+        return "ok"
+
+    assert flaky() == "ok"
+    assert calls["count"] == 2
+
+
+def test_retry_raises_after_exhaustion():
+    @retry(retries=1, delay=0)
+    def always_fail():
+        raise RuntimeError("fail")
+
+    try:
+        always_fail()
+    except RuntimeError:
+        pass
+    else:
+        assert False, "RuntimeError not raised"

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -1,0 +1,19 @@
+import time
+
+from src.core.utils.watchdog import Watchdog
+
+
+def test_watchdog_alerts_on_failure():
+    alerts: list[str] = []
+
+    def check():
+        raise RuntimeError("fail")
+
+    def alert(exc: BaseException) -> None:
+        alerts.append(str(exc))
+
+    wd = Watchdog(0.01, check, alert)
+    wd.start()
+    time.sleep(0.03)
+    wd.stop()
+    assert alerts, "Watchdog did not report failure"


### PR DESCRIPTION
## Summary
- add config validator ensuring required JSON files exist
- create retry decorator and apply to startup sequence
- introduce watchdog utility for periodic health checks
- include tests for validator, retry logic, and watchdog alerts

## Testing
- `pytest tests/test_config_validator.py tests/test_retry.py tests/test_watchdog.py`
- `pytest` *(fails: ImportError: cannot import name 'AgentCellPhone' from 'agent_cell_phone'; ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68a0a46171208329a5f090c6baf5bb4f