### PR TITLE
feat: add runtime mode configuration

### DIFF
--- a/docs/CONFIG_STRUCTURE.md
+++ b/docs/CONFIG_STRUCTURE.md
@@ -14,6 +14,7 @@ src/runtime/config/
 
 **Files:**
 - `cursor_agent_coords.json` - Agent coordinate mappings for different GUI layouts (2-agent, 4-agent, 8-agent)
+- `modes_runtime.json` - Autonomous mode pipeline and autopolicy configuration
 - `templates/agent_modes.json` - Agent mode templates and configurations
 
 ### Templates

--- a/runtime/config/modes_runtime.json
+++ b/runtime/config/modes_runtime.json
@@ -1,0 +1,25 @@
+{
+  "autopolicy": {
+    "resume_on_error": true,
+    "max_retries_per_mode": 3,
+    "default_new_chat": true
+  },
+  "pipeline": {
+    "stages": [
+      "ideation_to_prd",
+      "tasklist_autogen"
+    ]
+  },
+  "modes": {
+    "ideation_to_prd": {
+      "description": "Convert an initial product idea into a detailed product requirements document.",
+      "prompt_template": "[IDEATION→PRD] {agent_id} convert idea to PRD.",
+      "next": "tasklist_autogen"
+    },
+    "tasklist_autogen": {
+      "description": "Generate a development task list from a PRD.",
+      "prompt_template": "[TASKLIST] {agent_id} derive actionable tasks from PRD.",
+      "next": null
+    }
+  }
+}

--- a/src/config_validator.py
+++ b/src/config_validator.py
@@ -18,6 +18,7 @@ REQUIRED_FILES = [
     "config/system/system_config.json",
     "config/templates/agent_modes.json",
     "config/templates/message_templates.json",
+    "runtime/config/modes_runtime.json",
 ]
 
 

--- a/src/services/agent_cell_phone.py
+++ b/src/services/agent_cell_phone.py
@@ -48,7 +48,8 @@ except ImportError:
 REPO_ROOT   = Path(__file__).resolve().parent.parent.parent    # Go up to project root (from src/services/)
 CONFIG_DIR  = REPO_ROOT / "runtime" / "config"
 COORD_FILE  = REPO_ROOT / "runtime" / "agent_comms" / "cursor_agent_coords.json"
-MODE_FILE   = REPO_ROOT / "config" / "templates" / "agent_modes.json"
+# Mode configuration now lives in runtime/config to support autonomous pipelines
+MODE_FILE   = CONFIG_DIR / "modes_runtime.json"
 CAPTURE_CONFIG_FILE = CONFIG_DIR / "agent_capture.yaml"
 
 # ──────────────────────────── logging


### PR DESCRIPTION
## Summary
- define autonomous pipeline in `modes_runtime.json` with global autopolicy, stages, and per-mode prompts
- load runtime mode config from `runtime/config` and validate its presence on startup
- document new runtime mode file in configuration structure

## Testing
- `python -m json.tool runtime/config/modes_runtime.json`
- `pytest` *(fails: ImportError: cannot import name 'AgentCellPhone'; ModuleNotFoundError: pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c9c2699c83299b92f4bcb34508e6