### PR TITLE
Fix diagnostic script entry and imports

### DIFF
--- a/tests/diagnostic_test.py
+++ b/tests/diagnostic_test.py
@@ -18,8 +18,8 @@ sys.path.insert(0, str(SRC))
 
 def main() -> int:
     try:
-        from agent_cell_phone import AgentCellPhone  # type: ignore
-        from inter_agent_framework import InterAgentFramework  # type: ignore
+        from services.agent_cell_phone import AgentCellPhone  # type: ignore
+        from services.inter_agent_framework import InterAgentFramework  # type: ignore
     except Exception as e:
         print(f"[DIAG] import error: {e}")
         return 1
@@ -42,4 +42,4 @@ def main() -> int:
     return 0
 
 if __name__ == "__main__":
-    test_broadcast_with_delays()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Replace undefined test call with main() entry point
- Import AgentCellPhone and InterAgentFramework from services modules

## Testing
- `python tests/diagnostic_test.py`
- `pytest tests/diagnostic_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0cc8cf6ec83299cba016031c11ebc