### PR TITLE
Add lifecycle orchestrator with mode-based stages

### DIFF
--- a/agent_cell_phone.py
+++ b/agent_cell_phone.py
@@ -7,5 +7,5 @@ work even after the project was reorganised into a ``src``
 layout.
 """
 
-from src.agent_cell_phone import *  # noqa: F401,F403
+from src.services.agent_cell_phone import *  # noqa: F401,F403
 

--- a/orchestrators/__init__.py
+++ b/orchestrators/__init__.py
@@ -1,0 +1,1 @@
+"""Helper package for orchestration scripts."""

--- a/orchestrators/lifecycle_orchestrator.py
+++ b/orchestrators/lifecycle_orchestrator.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Simple lifecycle orchestrator for AgentCellPhone stages.
+
+Loads runtime configuration from ``runtime/config/modes_runtime.json`` and
+iterates through the common stages for a given mode.  Each stage specifies the
+agent that should run it, how many iterations (``budget``) to allow, and an
+optional gate check that determines whether the stage should run at all.
+
+The orchestrator integrates with :mod:`agent_cell_phone` to execute the stages
+by sending messages to the appropriate agents.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+from agent_cell_phone import AgentCellPhone
+from src.core.config_loader import load_config
+
+# ---------------------------------------------------------------------------
+# Gate check registry
+GateFn = Callable[[Dict[str, Any]], bool]
+
+
+def _gate_pass(_: Dict[str, Any]) -> bool:
+    return True
+
+
+def _gate_fail(_: Dict[str, Any]) -> bool:
+    return False
+
+
+GATES: Dict[str, GateFn] = {
+    "pass": _gate_pass,
+    "fail": _gate_fail,
+}
+
+
+class LifecycleOrchestrator:
+    """Orchestrate execution of common stages for a specific mode."""
+
+    def __init__(self, mode: str, ctx: Optional[Dict[str, Any]] = None,
+                 phone: Optional[AgentCellPhone] = None) -> None:
+        self.mode = mode
+        self.ctx: Dict[str, Any] = ctx or {}
+        self.phone = phone or AgentCellPhone(test=True)
+        self.config = self._load_config()
+
+    # ------------------------------------------------------------------ utils
+    @staticmethod
+    def _config_path() -> Path:
+        repo_root = Path(load_config()["paths"]["repo_root"])
+        return repo_root / "runtime" / "config" / "modes_runtime.json"
+
+    def _load_config(self) -> Dict[str, Any]:
+        cfg_path = self._config_path()
+        with open(cfg_path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+
+    # ----------------------------------------------------------------- running
+    def run(self) -> None:
+        stages: List[str] = self.config.get("stages", [])
+        mode_cfg: Dict[str, Any] = self.config.get("modes", {}).get(self.mode, {})
+        for stage in stages:
+            spec = mode_cfg.get(stage)
+            if not spec:
+                continue
+            gate_name = spec.get("gate", "pass")
+            gate_fn = GATES.get(gate_name, _gate_pass)
+            if not gate_fn(self.ctx):
+                continue
+            agent = spec.get("agent")
+            budget = int(spec.get("budget", 1))
+            for _ in range(budget):
+                self.phone.send(agent, f"Executing {stage}")
+
+
+# ---------------------------------------------------------------------------
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Lifecycle orchestrator")
+    parser.add_argument("--mode", required=True, help="Mode from modes_runtime.json")
+    parser.add_argument("--ctx", default="{}", help="JSON string with context")
+    args = parser.parse_args(argv)
+    ctx = json.loads(args.ctx)
+    orchestrator = LifecycleOrchestrator(args.mode, ctx)
+    orchestrator.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/runtime/config/modes_runtime.json
+++ b/runtime/config/modes_runtime.json
@@ -1,0 +1,13 @@
+{
+  "stages": ["init", "main"],
+  "modes": {
+    "test": {
+      "init": {"agent": "Agent-1", "budget": 1, "gate": "pass"},
+      "main": {"agent": "Agent-2", "budget": 2, "gate": "pass"}
+    },
+    "gated": {
+      "init": {"agent": "Agent-1", "budget": 1, "gate": "fail"},
+      "main": {"agent": "Agent-2", "budget": 2, "gate": "pass"}
+    }
+  }
+}

--- a/tests/test_lifecycle_orchestrator.py
+++ b/tests/test_lifecycle_orchestrator.py
@@ -1,0 +1,27 @@
+import json
+from unittest.mock import patch
+
+from orchestrators.lifecycle_orchestrator import LifecycleOrchestrator
+from agent_cell_phone import AgentCellPhone
+
+
+def test_stage_budget_respected():
+    phone = AgentCellPhone(test=True)
+    with patch.object(phone, "send") as mock_send:
+        orch = LifecycleOrchestrator("test", {}, phone)
+        orch.run()
+        stage1_calls = [c for c in mock_send.call_args_list if c.args[0] == "Agent-1"]
+        stage2_calls = [c for c in mock_send.call_args_list if c.args[0] == "Agent-2"]
+        assert len(stage1_calls) == 1
+        assert len(stage2_calls) == 2
+
+
+def test_gate_prevents_stage():
+    phone = AgentCellPhone(test=True)
+    with patch.object(phone, "send") as mock_send:
+        orch = LifecycleOrchestrator("gated", {}, phone)
+        orch.run()
+        stage1_calls = [c for c in mock_send.call_args_list if c.args[0] == "Agent-1"]
+        stage2_calls = [c for c in mock_send.call_args_list if c.args[0] == "Agent-2"]
+        assert len(stage1_calls) == 0
+        assert len(stage2_calls) == 2


### PR DESCRIPTION
## Summary
- implement lifecycle orchestrator that reads runtime stage definitions and dispatches per-mode agents
- expose CLI entry point for mode/ctx and integrate with AgentCellPhone messaging
- add config and tests validating stage budgets and gate checks
- reuse existing config loader and package orchestrators for cleaner integration

## Testing
- `pytest tests/test_lifecycle_orchestrator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0c9c38310832999f6424f3ed296c9