### PR TITLE
Safely parse gate expressions

### DIFF
--- a/src/core/lifecycle_orchestrator.py
+++ b/src/core/lifecycle_orchestrator.py
@@ -1,0 +1,86 @@
+"""Lifecycle orchestration utilities."""
+from __future__ import annotations
+
+import ast
+import logging
+from typing import Mapping
+
+
+logger = logging.getLogger(__name__)
+
+
+class _GateEvaluator(ast.NodeVisitor):
+    """Safely evaluate a boolean gate expression.
+
+    Only a minimal subset of Python's AST is supported:
+    - Boolean operations: ``and`` / ``or``
+    - Unary negation: ``not``
+    - Parentheses (handled by AST structure)
+    - Boolean constants: ``True`` / ``False``
+    - Names mapped to boolean values supplied via ``context``
+
+    Any other syntax results in a ``ValueError``.
+    """
+
+    def __init__(self, context: Mapping[str, bool]):
+        self.context = context
+
+    # Entry point
+    def visit_Expression(self, node: ast.Expression) -> bool:  # pragma: no cover - delegator
+        return self.visit(node.body)
+
+    # Boolean operations: and / or
+    def visit_BoolOp(self, node: ast.BoolOp) -> bool:
+        if isinstance(node.op, ast.And):
+            return all(self.visit(v) for v in node.values)
+        if isinstance(node.op, ast.Or):
+            return any(self.visit(v) for v in node.values)
+        raise ValueError("Unsupported boolean operator")
+
+    # Unary operations: not
+    def visit_UnaryOp(self, node: ast.UnaryOp) -> bool:
+        if isinstance(node.op, ast.Not):
+            return not self.visit(node.operand)
+        raise ValueError("Unsupported unary operator")
+
+    # Names -> lookup in context
+    def visit_Name(self, node: ast.Name) -> bool:
+        if node.id in self.context:
+            return bool(self.context[node.id])
+        raise ValueError(f"Unknown gate: {node.id}")
+
+    # Boolean constants
+    def visit_Constant(self, node: ast.Constant) -> bool:
+        if isinstance(node.value, bool):
+            return node.value
+        raise ValueError("Only boolean constants allowed")
+
+    # Disallow all other nodes
+    def generic_visit(self, node: ast.AST):  # pragma: no cover - error path
+        raise ValueError(f"Unsupported expression: {type(node).__name__}")
+
+
+def gate_pass(expr: str, context: Mapping[str, bool]) -> bool:
+    """Return ``True`` if the gate expression evaluates to truthy.
+
+    Parameters
+    ----------
+    expr:
+        A string containing a boolean expression referencing gates in ``context``.
+    context:
+        Mapping of gate names to boolean values.
+
+    Returns
+    -------
+    bool
+        Result of the evaluated expression. If parsing fails or unsupported
+        tokens are encountered, ``False`` is returned.
+    """
+
+    try:
+        tree = ast.parse(expr, mode="eval")
+        evaluator = _GateEvaluator(context)
+        return bool(evaluator.visit(tree))
+    except Exception as exc:
+        logger.debug("gate_pass parse error: %s", exc)
+        return False

--- a/tests/test_lifecycle_orchestrator.py
+++ b/tests/test_lifecycle_orchestrator.py
@@ -1,0 +1,26 @@
+import pytest
+
+from src.core.lifecycle_orchestrator import gate_pass
+
+
+def test_gate_pass_basic_operations():
+    ctx = {"A": True, "B": False, "C": True}
+    assert gate_pass("A and not B", ctx) is True
+    assert gate_pass("A and B", ctx) is False
+    assert gate_pass("A or B and C", ctx) is True  # "A or (B and C)" -> True
+
+
+def test_gate_pass_unknown_name_is_false():
+    ctx = {"A": True}
+    assert gate_pass("A and B", ctx) is False
+
+
+def test_gate_pass_parse_error_returns_false():
+    ctx = {"A": True, "B": True}
+    assert gate_pass("A && B", ctx) is False
+
+
+def test_gate_pass_unsupported_tokens_return_false():
+    ctx = {"A": True, "B": True}
+    assert gate_pass("A + B", ctx) is False
+    assert gate_pass("__import__('os')", ctx) is False


### PR DESCRIPTION
## Summary
- Implement lifecycle gating utility that evaluates boolean expressions via Python AST, rejecting unknown gates or unsupported syntax
- Add unit tests covering normal operations, unknown names, parse errors, and unsupported tokens
- Log gate expression parse failures for easier diagnostics

## Testing
- `pytest tests/test_lifecycle_orchestrator.py -q`
- `pytest -q` *(fails: cannot import AgentCellPhone; ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68a0c9c506388329b5ba45bf849073fc