### PR TITLE
Add watchdog integration for stalled operations

### DIFF
--- a/src/core/autonomy_guard.py
+++ b/src/core/autonomy_guard.py
@@ -1,0 +1,35 @@
+"""High level guard utilities for ensuring agent autonomy processes do not stall."""
+
+from __future__ import annotations
+
+from typing import Callable, Mapping
+
+from .watchdog_integration import WatchdogIntegration
+
+
+def enforce(
+    operation: Callable[[Callable[[], None]], None],
+    autopolicy: Mapping[str, int],
+    on_recover: Callable[[], None],
+) -> None:
+    """Run an operation while watching for stalls.
+
+    Parameters
+    ----------
+    operation: Callable[[Callable[[], None]], None]
+        Function representing a commit or test process. It receives a
+        ``signal_progress`` callback and should invoke it whenever progress
+        is made.
+    autopolicy: Mapping[str, int]
+        Policy configuration containing ``probe_timeout_ms``.
+    on_recover: Callable[[], None]
+        Callback invoked if the watchdog determines the operation has
+        stalled.
+    """
+
+    watchdog = WatchdogIntegration(autopolicy, on_recover)
+    watchdog.start()
+    try:
+        operation(watchdog.signal_progress)
+    finally:
+        watchdog.stop()

--- a/src/core/watchdog_integration.py
+++ b/src/core/watchdog_integration.py
@@ -1,0 +1,47 @@
+"""Integration layer leveraging the shared watchdog utility.
+
+This module wires the generic :class:`~src.core.utils.watchdog.Watchdog`
+into a simple progress-based monitor.  When no progress has been signalled
+within the ``probe_timeout_ms`` from the provided autopolicy, a recovery
+callback is invoked.  By delegating scheduling and threading concerns to
+the existing watchdog utility we avoid duplicating infrastructure.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Callable, Mapping
+
+from .utils.watchdog import Watchdog
+
+
+class WatchdogIntegration:
+    """Monitor progress and invoke a recovery action when stalled."""
+
+    def __init__(self, autopolicy: Mapping[str, int], on_recover: Callable[[], None]) -> None:
+        self.probe_timeout_ms = int(autopolicy.get("probe_timeout_ms", 1000))
+        self.on_recover = on_recover
+        self._last_progress = time.monotonic()
+
+        timeout = self.probe_timeout_ms / 1000.0
+        interval = min(0.1, timeout / 2)
+        self._watchdog = Watchdog(interval, self._check)
+
+    def signal_progress(self) -> None:
+        """Record that some progress has been made."""
+        self._last_progress = time.monotonic()
+
+    def _check(self) -> None:
+        if time.monotonic() - self._last_progress > self.probe_timeout_ms / 1000.0:
+            self.on_recover()
+            # Reset progress to avoid continuous triggering until action updates
+            self.signal_progress()
+
+    def start(self) -> None:
+        """Start monitoring in a background thread via the shared watchdog."""
+        self._watchdog.start()
+
+    def stop(self) -> None:
+        """Stop monitoring."""
+        self._watchdog.stop()
+

--- a/tests/test_autonomy_guard.py
+++ b/tests/test_autonomy_guard.py
@@ -1,0 +1,19 @@
+import time
+
+from src.core.autonomy_guard import enforce
+
+
+def test_enforce_triggers_recovery_on_stall():
+    autopolicy = {"probe_timeout_ms": 20}
+    recovered = {"called": False}
+
+    def stalled_operation(signal_progress):
+        # No progress is signalled; sleep longer than the timeout
+        time.sleep(0.05)
+
+    def recover():
+        recovered["called"] = True
+
+    enforce(stalled_operation, autopolicy, recover)
+
+    assert recovered["called"], "Recovery action was not triggered for stalled operation"


### PR DESCRIPTION
## Summary
- add `WatchdogIntegration` to monitor progress using `probe_timeout_ms` from autopolicy
- expose `autonomy_guard.enforce` helper to run operations with the watchdog
- add test ensuring stalled operations trigger recovery
- refactor watchdog integration to reuse existing `utils.watchdog` infrastructure

## Testing
- `pytest tests/test_autonomy_guard.py tests/test_watchdog.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'AgentCellPhone'; ModuleNotFoundError: pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c9c7a55c83299b81a8345a55551d