### PR TITLE
Add autonomous mode guide and orchestrator guard tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@
 - **FSM workflow automation** triggered by AI responses
 - Skip all human-like behavior; pure mechanical precision
 
+For a high-level guide to autonomous modes, pipelines, guardrails, and Discord commands, see [AutonomousModes.md](docs/AutonomousModes.md).
+
 ## 🚀 Quick Start
 
 ### **🎯 NEW: Bi-Directional AI Communication (v1.0.0)**
@@ -178,6 +180,12 @@ acp.broadcast("Status update: All systems operational")
 - **Multiple fallback strategies** including Export Chat processing
 - **Cross-platform support** (Windows, macOS, Linux)
 - **Zero UI interaction** - completely headless operation
+
+## End-to-End Autonomous Flow
+1. Tasks are planned and queued.
+2. The overnight runner clones repositories, runs guard commands, and advances task state.
+3. The FSM orchestrator persists state and emits verification messages.
+4. Digests and optional Discord notifications summarize outcomes.
 
 ## 📁 Project Structure
 

--- a/docs/AutonomousModes.md
+++ b/docs/AutonomousModes.md
@@ -1,0 +1,21 @@
+# Autonomous Modes
+
+This guide summarizes the autonomous operating modes used by Agent Cell Phone and how tasks move through the system.
+
+## Modes
+- **2, 4, or 8 Agent Layouts** – GUI selections allow small or large collaborations.
+- **5‑Agent Overnight Runner** – orchestrates contracts and FSM updates for continuous hands‑off operation.
+
+## Pipelines
+1. **Message Pipeline** – lightweight in‑memory queue for routing messages between agents.
+2. **FSM Orchestrator** – consumes inbox updates, maintains task state, and emits verification messages.
+3. **Overnight Runner** – polls tasks, executes guard commands, and advances states.
+
+## Guardrails
+- Guard commands in `config/fsm.yml` enforce linting, tests, and deployment checks before transitions.
+- Non‑actionable states remain parked until prerequisites are met, preventing accidental progress.
+- Output from guard commands is truncated to keep artifacts within budget.
+
+## Discord Command Usage
+- Commands follow `@agent-x <command>` syntax (`@all`, `@self` are also supported).
+- Set `DISCORD_WEBHOOK_URL` to broadcast digests and task status to a shared channel.

--- a/tests/unit/test_overnight_runner_guards.py
+++ b/tests/unit/test_overnight_runner_guards.py
@@ -1,0 +1,34 @@
+import pathlib
+import sys
+import types
+
+# Stub yaml module to satisfy dependency if PyYAML is missing
+yaml_stub = types.ModuleType("yaml")
+yaml_stub.safe_load = lambda *args, **kwargs: {}
+sys.modules.setdefault("yaml", yaml_stub)
+
+from orchestrators.overnight_runner import run_guard, advance_state, process_task, Task
+
+
+def test_run_guard_truncates_output(tmp_path: pathlib.Path) -> None:
+    script = tmp_path / "big.py"
+    script.write_text("print('a'*6000)")
+    result = run_guard("big", f"python {script.name}", tmp_path)
+    assert result["ok"]
+    assert len(result["stdout"]) == 5000
+    assert result["stdout"].endswith("\n")
+    assert set(result["stdout"].strip()) == {"a"}
+
+
+def test_advance_state_gates() -> None:
+    fsm = {"states": {"Build": {"on_pass": "Review", "on_fail": "Quarantine"}}}
+    assert advance_state(fsm, "Build", True) == "Review"
+    assert advance_state(fsm, "Build", False) == "Quarantine"
+    assert advance_state(fsm, "Unknown", True) == "Unknown"
+
+
+def test_process_task_blocks_non_actionable() -> None:
+    task = Task(id="1", repo="r", branch="main", state="Plan")
+    result = process_task(task, {"states": {}})
+    assert result["note"].startswith("Skipped")
+    assert result["from"] == "Plan" and result["to"] == "Plan"

--- a/tests/unit/test_task_router.py
+++ b/tests/unit/test_task_router.py
@@ -1,0 +1,46 @@
+import asyncio
+import pathlib
+import sys
+
+import pytest
+
+# Allow importing TaskRouter without executing package __init__
+repo_root = pathlib.Path(__file__).resolve().parents[2]
+sys.path.append(str(repo_root / "project_repository" / "orchestrator"))
+from task_router import TaskRouter  # type: ignore
+
+
+def test_prd_ingest_and_task_budget() -> None:
+    router = TaskRouter()
+    prd = {"name": "demo", "requirements": ["feat1", "feat2"]}
+    tasks = router.ingest_prd(prd)
+    assert len(tasks) == 2
+    assert router.task_counter == 2  # budget reflects total tasks
+
+    t1 = asyncio.run(router.get_next_task("Agent-1"))
+    assert t1["status"] == "assigned"
+    t2 = asyncio.run(router.get_next_task("Agent-2"))
+    assert t2["id"] != t1["id"]
+
+
+def test_task_assignment_gate_and_path_blocking() -> None:
+    router = TaskRouter()
+    prd = {"name": "demo", "requirements": ["feat"]}
+    router.ingest_prd(prd)
+    asyncio.run(router.get_next_task("Agent-1"))
+    # Agent-1 already has a task, gate returns same task
+    same = asyncio.run(router.get_next_task("Agent-1"))
+    assert same["assigned_to"] == "Agent-1"
+    # No more tasks remain; Agent-2 is blocked
+    assert asyncio.run(router.get_next_task("Agent-2")) is None
+
+
+def test_complete_task_updates_status() -> None:
+    router = TaskRouter()
+    prd = {"name": "demo", "requirements": ["feat"]}
+    router.ingest_prd(prd)
+    task = asyncio.run(router.get_next_task("Agent-1"))
+    asyncio.run(router.complete_task("Agent-1", task))
+    status = router.get_system_status()
+    assert status["tasks"]["completed"] == 1
+    assert status["tasks"]["completion_rate"] == 100


### PR DESCRIPTION
## Summary
- Document autonomous modes, pipelines, guardrails, and Discord commands
- Link README to new guide and outline end-to-end autonomous flow
- Add unit tests for overnight runner guards and task router budgets/gates

## Testing
- `pytest tests/unit/test_overnight_runner_guards.py tests/unit/test_task_router.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0c9c933108329a3071faaee29212e