### PR TITLE
Fix NameError in inter-agent framework tests

### DIFF
--- a/tests/test_inter_agent_framework.py
+++ b/tests/test_inter_agent_framework.py
@@ -16,6 +16,39 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
 from services.inter_agent_framework import InterAgentFramework, Message, MessageType
 
 
+def test_agent_communication() -> None:
+    """Ensure messages can be sent between agents"""
+    iaf = InterAgentFramework("Agent-1", layout_mode="2-agent", test=True)
+
+    msg = Message(
+        sender="Agent-1",
+        recipient="Agent-2",
+        message_type=MessageType.COMMAND,
+        command="ping",
+    )
+
+    assert iaf.send_message("Agent-2", msg)
+    assert iaf.message_history[-1].command == "ping"
+
+
+def test_agent_responses() -> None:
+    """Verify that command handlers send a response"""
+    iaf = InterAgentFramework("Agent-1", layout_mode="2-agent", test=True)
+
+    incoming = Message(
+        sender="Agent-2",
+        recipient="Agent-1",
+        message_type=MessageType.COMMAND,
+        command="ping",
+    )
+
+    result = iaf._handle_ping(incoming)
+
+    assert result == "Ping responded"
+    assert iaf.message_history[-1].recipient == "Agent-2"
+    assert iaf.message_history[-1].command == "pong"
+
+
 def test_framework_sends_structured_message():
     iaf = InterAgentFramework("Agent-1", layout_mode="2-agent", test=True)
 


### PR DESCRIPTION
## Summary
- add concrete `test_agent_communication` and `test_agent_responses` to `tests/test_inter_agent_framework.py`
- ensure direct script execution runs without NameError by providing implementations

## Testing
- `pytest tests/test_inter_agent_framework.py -q`
- `python tests/test_inter_agent_framework.py`

------
https://chatgpt.com/codex/tasks/task_e_68a0cc8988e48329b3658c97b9ee7ea1