### PR TITLE
Ensure atomic writes for captured responses

### DIFF
--- a/src/cursor_capture/watcher.py
+++ b/src/cursor_capture/watcher.py
@@ -4,6 +4,7 @@ import time
 from pathlib import Path
 from typing import Dict, List
 from .db_reader import read_assistant_messages
+from ..utils import atomic_write
 
 # Configuration
 INBOX = Path("agent_workspaces/Agent-5/inbox")
@@ -100,9 +101,9 @@ class CursorDBWatcher:
                         }
                     }
                     
-                    # Write to inbox
+                    # Write to inbox atomically
                     out = INBOX / f"assistant_{int(time.time()*1000)}_{agent}.json"
-                    out.write_text(json.dumps(env, ensure_ascii=False, indent=2), encoding="utf-8")
+                    atomic_write(out, json.dumps(env, ensure_ascii=False, indent=2))
                     
                     print(f"[CURSOR_WATCHER] Captured AI response from {agent}: {len(m['text'])} chars")
                 

--- a/src/services/enhanced_response_capture.py
+++ b/src/services/enhanced_response_capture.py
@@ -13,6 +13,7 @@ import re
 import threading
 import asyncio
 from pathlib import Path
+from ..utils import atomic_write
 from dataclasses import dataclass
 from typing import Optional, Dict, Callable, List, Any
 from enum import Enum
@@ -302,7 +303,7 @@ class EnhancedResponseCapture:
             }
             
             out_file = Path(self.config.workflow_inbox) / f"response_{int(time.time()*1000)}_{response.agent}.json"
-            out_file.write_text(json.dumps(envelope, ensure_ascii=False, indent=2), encoding="utf-8")
+            atomic_write(out_file, json.dumps(envelope, ensure_ascii=False, indent=2))
             
         except Exception as e:
             print(f"[ENHANCED_CAPTURE] Error routing to workflow: {e}")
@@ -322,7 +323,7 @@ class EnhancedResponseCapture:
             }
             
             out_file = Path(self.config.fsm_inbox) / f"response_{int(time.time()*1000)}_{response.agent}.json"
-            out_file.write_text(json.dumps(envelope, ensure_ascii=False, indent=2), encoding="utf-8")
+            atomic_write(out_file, json.dumps(envelope, ensure_ascii=False, indent=2))
             
         except Exception as e:
             print(f"[ENHANCED_CAPTURE] Error routing to FSM: {e}")

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import Union
+
+
+def atomic_write(path: Union[str, Path], data: str) -> None:
+    """Atomically write text data to a file.
+
+    The data is first written to a temporary file in the same directory and
+    then moved into place. This prevents readers from observing a partially
+    written file.
+    """
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.with_suffix(p.suffix + ".tmp")
+    tmp.write_text(data, encoding="utf-8")
+    tmp.replace(p)


### PR DESCRIPTION
## Summary
- add `atomic_write` helper and use in response capture paths
- write workflow and FSM output files atomically
- atomically emit CursorDB watcher events
- test that watcher outputs leave no partial files

## Testing
- `pytest tests/test_cursor_capture.py::test_cursor_watcher_outputs_no_partial_files -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2073c75e483299474a4de59f5481f