### PR TITLE
Add queue clearing to PyAutoGUI messaging system

### DIFF
--- a/src/services/agent_cell_phone.py
+++ b/src/services/agent_cell_phone.py
@@ -429,18 +429,20 @@ class AgentCellPhone:
 
     def clear_queue(self) -> bool:
         """Clear the PyAutoGUI message queue.
-        
+
         Returns:
             True if queue was cleared, False otherwise
         """
         if not self._pyautogui_queue:
             return False
-        
+
         try:
-            # This would need to be implemented in the PyAutoGUIQueue class
-            # For now, we'll just log the request
-            log.info("Queue clear requested (not yet implemented)")
-            return False
+            result = self._pyautogui_queue.clear_queue()
+            if result:
+                log.info("PyAutoGUI queue cleared")
+            else:
+                log.warning("PyAutoGUI queue clear failed")
+            return result
         except Exception as e:
             log.error("Queue clear error: %s", e)
             return False


### PR DESCRIPTION
## Summary
- implement `clear_queue` in `PyAutoGUIQueue` to stop processing, drain messages, and release locks
- wire `AgentCellPhone.clear_queue` to invoke the queue and log results
- test queue clearing to ensure messages and locks are removed

## Testing
- `pytest tests/test_agent_cell_phone.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a207732d808329bc421448c40c8c87